### PR TITLE
fix: Installed pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,13 @@ upgrade-pip-tools: pip-tools
 	pip-compile --upgrade requirements/pip-tools.in
 
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
-upgrade: upgrade-pip-tools ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
+upgrade:  ## update the requirements/*.txt files with the latest packages satisfying requirements/*.in
 	# Make sure to compile files after any other files they include!
-	make pip-tools  # Reinstall pip-tools in case it was upgraded.
+	pip install -qr requirements/pip-tools.txt
+	pip-compile --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
 	pip-compile --upgrade --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
+	pip install -qr requirements/pip-tools.txt
+	pip install -qr requirements/pip.txt
 	pip-compile --upgrade requirements/base.in
 	pip-compile --upgrade requirements/test.in
 	pip-compile --upgrade requirements/doc.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -46,7 +46,7 @@ pytz==2022.1
     # via
     #   django
     #   djangorestframework
-requests==2.27.1
+requests==2.28.0
     # via coreapi
 ruamel-yaml==0.17.21
     # via drf-yasg

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -10,11 +10,11 @@ charset-normalizer==2.0.12
     # via requests
 codecov==2.1.12
     # via -r requirements/ci.in
-coverage==6.4
+coverage==6.4.1
     # via codecov
 distlib==0.3.4
     # via virtualenv
-filelock==3.7.0
+filelock==3.7.1
     # via
     #   tox
     #   virtualenv
@@ -30,7 +30,7 @@ py==1.11.0
     # via tox
 pyparsing==3.0.9
     # via packaging
-requests==2.27.1
+requests==2.28.0
     # via codecov
 six==1.16.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ asgiref==3.5.2
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.11.5
+astroid==2.11.6
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -26,10 +26,6 @@ certifi==2022.5.18.1
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   requests
-cffi==1.15.0
-    # via
-    #   -r requirements/quality.txt
-    #   cryptography
 chardet==4.0.0
     # via diff-cover
 charset-normalizer==2.0.12
@@ -68,16 +64,12 @@ coreschema==0.0.4
     #   -r requirements/quality.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.4
+coverage[toml]==6.4.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   codecov
     #   pytest-cov
-cryptography==37.0.2
-    # via
-    #   -r requirements/quality.txt
-    #   secretstorage
 diff-cover==6.5.0
     # via -r requirements/dev.in
 dill==0.3.5.1
@@ -107,9 +99,9 @@ drf-yasg==1.20.0
     # via -r requirements/quality.txt
 edx-i18n-tools==0.9.1
     # via -r requirements/dev.in
-edx-lint==5.2.2
+edx-lint==5.2.4
     # via -r requirements/quality.txt
-filelock==3.7.0
+filelock==3.7.1
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -140,18 +132,13 @@ itypes==1.2.0
     # via
     #   -r requirements/quality.txt
     #   coreapi
-jeepney==0.8.0
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/quality.txt
     #   code-annotations
     #   coreschema
     #   diff-cover
-keyring==23.5.1
+keyring==23.6.0
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -186,7 +173,7 @@ pep517==0.12.0
     #   pip-tools
 pip-tools==6.6.2
     # via -r requirements/pip-tools.txt
-pkginfo==1.8.2
+pkginfo==1.8.3
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -213,10 +200,6 @@ py==1.11.0
     #   tox
 pycodestyle==2.8.0
     # via -r requirements/quality.txt
-pycparser==2.21
-    # via
-    #   -r requirements/quality.txt
-    #   cffi
 pydocstyle==6.1.1
     # via -r requirements/quality.txt
 pygments==2.12.0
@@ -225,7 +208,7 @@ pygments==2.12.0
     #   diff-cover
     #   readme-renderer
     #   rich
-pylint==2.13.9
+pylint==2.14.1
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -277,7 +260,7 @@ readme-renderer==35.0
     # via
     #   -r requirements/quality.txt
     #   twine
-requests==2.27.1
+requests==2.28.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -305,10 +288,6 @@ ruamel-yaml-clib==0.2.6
     # via
     #   -r requirements/quality.txt
     #   ruamel-yaml
-secretstorage==3.3.2
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
 six==1.16.0
     # via
     #   -r requirements/ci.txt
@@ -345,13 +324,17 @@ tomli==2.0.1
     #   pep517
     #   pylint
     #   pytest
+tomlkit==0.11.0
+    # via
+    #   -r requirements/quality.txt
+    #   pylint
 tox==3.25.0
     # via
     #   -r requirements/ci.txt
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/dev.in
-twine==4.0.0
+twine==4.0.1
     # via -r requirements/quality.txt
 typing-extensions==4.2.0
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -14,7 +14,7 @@ attrs==21.4.0
     # via
     #   -r requirements/test.txt
     #   pytest
-babel==2.10.1
+babel==2.10.2
     # via sphinx
 bleach==5.0.0
     # via readme-renderer
@@ -22,8 +22,6 @@ certifi==2022.5.18.1
     # via
     #   -r requirements/test.txt
     #   requests
-cffi==1.15.0
-    # via cryptography
 charset-normalizer==2.0.12
     # via
     #   -r requirements/test.txt
@@ -39,12 +37,10 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.4
+coverage[toml]==6.4.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==37.0.2
-    # via secretstorage
 django==3.2.13
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -57,7 +53,7 @@ djangorestframework==3.13.1
     #   drf-yasg
 doc8==0.11.2
     # via -r requirements/doc.in
-docutils==0.17.1
+docutils==0.18.1
     # via
     #   doc8
     #   readme-renderer
@@ -90,16 +86,12 @@ itypes==1.2.0
     # via
     #   -r requirements/test.txt
     #   coreapi
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
     #   coreschema
     #   sphinx
-keyring==23.5.1
+keyring==23.6.0
     # via twine
 markupsafe==2.1.1
     # via
@@ -113,7 +105,7 @@ packaging==21.3
     #   sphinx
 pbr==5.9.0
     # via stevedore
-pkginfo==1.8.2
+pkginfo==1.8.3
     # via twine
 pluggy==1.0.0
     # via
@@ -123,8 +115,6 @@ py==1.11.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pycparser==2.21
-    # via cffi
 pygments==2.12.0
     # via
     #   doc8
@@ -154,7 +144,7 @@ readme-renderer==35.0
     # via
     #   -r requirements/doc.in
     #   twine
-requests==2.27.1
+requests==2.28.0
     # via
     #   -r requirements/test.txt
     #   coreapi
@@ -177,15 +167,13 @@ ruamel-yaml-clib==0.2.6
     # via
     #   -r requirements/test.txt
     #   ruamel-yaml
-secretstorage==3.3.2
-    # via keyring
 six==1.16.0
     # via
     #   bleach
     #   edx-sphinx-theme
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.5.0
+sphinx==5.0.1
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -212,7 +200,7 @@ tomli==2.0.1
     #   -r requirements/test.txt
     #   coverage
     #   pytest
-twine==4.0.0
+twine==4.0.1
     # via -r requirements/doc.in
 typing-extensions==4.2.0
     # via rich

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.1.1
+pip==22.1.2
     # via -r requirements/pip.in
 setuptools==59.8.0
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -8,7 +8,7 @@ asgiref==3.5.2
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.11.5
+astroid==2.11.6
     # via
     #   pylint
     #   pylint-celery
@@ -22,8 +22,6 @@ certifi==2022.5.18.1
     # via
     #   -r requirements/test.txt
     #   requests
-cffi==1.15.0
-    # via cryptography
 charset-normalizer==2.0.12
     # via
     #   -r requirements/test.txt
@@ -48,12 +46,10 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.4
+coverage[toml]==6.4.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==37.0.2
-    # via secretstorage
 dill==0.3.5.1
     # via pylint
 django==3.2.13
@@ -70,7 +66,7 @@ docutils==0.18.1
     # via readme-renderer
 drf-yasg==1.20.0
     # via -r requirements/test.txt
-edx-lint==5.2.2
+edx-lint==5.2.4
     # via -r requirements/quality.in
 idna==3.3
     # via
@@ -96,16 +92,12 @@ itypes==1.2.0
     # via
     #   -r requirements/test.txt
     #   coreapi
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
     #   coreschema
-keyring==23.5.1
+keyring==23.6.0
     # via twine
 lazy-object-proxy==1.7.1
     # via astroid
@@ -122,7 +114,7 @@ packaging==21.3
     #   pytest
 pbr==5.9.0
     # via stevedore
-pkginfo==1.8.2
+pkginfo==1.8.3
     # via twine
 platformdirs==2.5.2
     # via pylint
@@ -136,15 +128,13 @@ py==1.11.0
     #   pytest
 pycodestyle==2.8.0
     # via -r requirements/quality.in
-pycparser==2.21
-    # via cffi
 pydocstyle==6.1.1
     # via -r requirements/quality.in
 pygments==2.12.0
     # via
     #   readme-renderer
     #   rich
-pylint==2.13.9
+pylint==2.14.1
     # via
     #   edx-lint
     #   pylint-celery
@@ -182,7 +172,7 @@ pyyaml==6.0
     # via code-annotations
 readme-renderer==35.0
     # via twine
-requests==2.27.1
+requests==2.28.0
     # via
     #   -r requirements/test.txt
     #   coreapi
@@ -202,8 +192,6 @@ ruamel-yaml-clib==0.2.6
     # via
     #   -r requirements/test.txt
     #   ruamel-yaml
-secretstorage==3.3.2
-    # via keyring
 six==1.16.0
     # via
     #   bleach
@@ -224,7 +212,9 @@ tomli==2.0.1
     #   coverage
     #   pylint
     #   pytest
-twine==4.0.0
+tomlkit==0.11.0
+    # via pylint
+twine==4.0.1
     # via -r requirements/quality.in
 typing-extensions==4.2.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -27,7 +27,7 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==6.4
+coverage[toml]==6.4.1
     # via pytest-cov
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -87,7 +87,7 @@ pytz==2022.1
     #   -r requirements/base.txt
     #   django
     #   djangorestframework
-requests==2.27.1
+requests==2.28.0
     # via
     #   -r requirements/base.txt
     #   coreapi


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this https://github.com/openedx/edx-repo-health/pull/271 for new check added in edx-repo-health.

JIRA: https://2u-internal.atlassian.net/browse/BOM-3456