### PR TITLE
build: Remove community-engineering CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @edx/community-engineering


### PR DESCRIPTION
Team no longer exists. See <https://github.com/edx/edx-arch-experiments/issues/132>.
