### PR TITLE
fix: remove tox-battery package and tox constraint

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,6 +4,12 @@
 #
 #    make upgrade
 #
+cachetools==5.3.2
+    # via tox
+chardet==5.2.0
+    # via tox
+colorama==0.4.6
+    # via tox
 distlib==0.3.7
     # via virtualenv
 filelock==3.13.1
@@ -11,20 +17,22 @@ filelock==3.13.1
     #   tox
     #   virtualenv
 packaging==23.2
-    # via tox
+    # via
+    #   pyproject-api
+    #   tox
 platformdirs==4.1.0
-    # via virtualenv
+    # via
+    #   tox
+    #   virtualenv
 pluggy==1.3.0
     # via tox
-py==1.11.0
-    # via tox
-six==1.16.0
+pyproject-api==1.6.1
     # via tox
 tomli==2.0.1
-    # via tox
-tox==3.28.0
     # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/ci.in
+    #   pyproject-api
+    #   tox
+tox==4.11.4
+    # via -r requirements/ci.in
 virtualenv==20.25.0
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,7 +10,3 @@
 
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-
-# tox>4.0.0 isn't yet compatible with many tox plugins, causing CI failures in almost all repos.
-# Details can be found in this discussion: https://github.com/tox-dev/tox/discussions/1810
-tox<4.0.0

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -7,4 +7,3 @@
 
 diff-cover                # Changeset diff test coverage
 edx-i18n-tools            # For i18n_tool dummy
-tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,16 +17,19 @@ build==1.0.3
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
+cachetools==5.3.2
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 certifi==2023.11.17
     # via
     #   -r requirements/quality.txt
     #   requests
-cffi==1.16.0
-    # via
-    #   -r requirements/quality.txt
-    #   cryptography
 chardet==5.2.0
-    # via diff-cover
+    # via
+    #   -r requirements/ci.txt
+    #   diff-cover
+    #   tox
 charset-normalizer==3.3.2
     # via
     #   -r requirements/quality.txt
@@ -47,15 +50,15 @@ code-annotations==1.5.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
+colorama==0.4.6
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 coverage[toml]==7.3.2
     # via
     #   -r requirements/quality.txt
     #   coverage
     #   pytest-cov
-cryptography==41.0.7
-    # via
-    #   -r requirements/quality.txt
-    #   secretstorage
 diff-cover==8.0.1
     # via -r requirements/dev.in
 dill==0.3.7
@@ -127,11 +130,6 @@ jaraco-classes==3.3.0
     # via
     #   -r requirements/quality.txt
     #   keyring
-jeepney==0.8.0
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/quality.txt
@@ -163,7 +161,7 @@ more-itertools==10.1.0
     # via
     #   -r requirements/quality.txt
     #   jaraco-classes
-nh3==0.2.14
+nh3==0.2.15
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
@@ -174,6 +172,7 @@ packaging==23.2
     #   -r requirements/quality.txt
     #   build
     #   drf-yasg
+    #   pyproject-api
     #   pytest
     #   tox
 path==16.9.0
@@ -193,6 +192,7 @@ platformdirs==4.1.0
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pylint
+    #   tox
     #   virtualenv
 pluggy==1.3.0
     # via
@@ -203,16 +203,8 @@ pluggy==1.3.0
     #   tox
 polib==1.2.0
     # via edx-i18n-tools
-py==1.11.0
-    # via
-    #   -r requirements/ci.txt
-    #   tox
 pycodestyle==2.11.1
     # via -r requirements/quality.txt
-pycparser==2.21
-    # via
-    #   -r requirements/quality.txt
-    #   cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
 pygments==2.17.2
@@ -241,6 +233,10 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/quality.txt
     #   pylint-celery
     #   pylint-django
+pyproject-api==1.6.1
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
@@ -291,16 +287,10 @@ rich==13.7.0
     # via
     #   -r requirements/quality.txt
     #   twine
-secretstorage==3.3.3
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
 six==1.16.0
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   edx-lint
-    #   tox
 snowballstemmer==2.2.0
     # via
     #   -r requirements/quality.txt
@@ -326,6 +316,7 @@ tomli==2.0.1
     #   coverage
     #   pip-tools
     #   pylint
+    #   pyproject-api
     #   pyproject-hooks
     #   pytest
     #   tox
@@ -333,13 +324,8 @@ tomlkit==0.12.3
     # via
     #   -r requirements/quality.txt
     #   pylint
-tox==3.28.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/ci.txt
-    #   tox-battery
-tox-battery==0.6.2
-    # via -r requirements/dev.in
+tox==4.11.4
+    # via -r requirements/ci.txt
 twine==4.0.2
     # via -r requirements/quality.txt
 typing-extensions==4.8.0

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -20,8 +20,6 @@ beautifulsoup4==4.12.2
     # via pydata-sphinx-theme
 certifi==2023.11.17
     # via requests
-cffi==1.16.0
-    # via cryptography
 charset-normalizer==3.3.2
     # via requests
 coverage[toml]==7.3.2
@@ -29,8 +27,6 @@ coverage[toml]==7.3.2
     #   -r requirements/test.txt
     #   coverage
     #   pytest-cov
-cryptography==41.0.7
-    # via secretstorage
 django==3.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -77,10 +73,6 @@ iniconfig==2.0.0
     #   pytest
 jaraco-classes==3.3.0
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via sphinx
 keyring==24.3.0
@@ -93,7 +85,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.1.0
     # via jaraco-classes
-nh3==0.2.14
+nh3==0.2.15
     # via readme-renderer
 packaging==23.2
     # via
@@ -110,8 +102,6 @@ pluggy==1.3.0
     # via
     #   -r requirements/test.txt
     #   pytest
-pycparser==2.21
-    # via cffi
 pydata-sphinx-theme==0.14.4
     # via sphinx-book-theme
 pygments==2.17.2
@@ -159,8 +149,6 @@ rfc3986==2.0.0
     # via twine
 rich==13.7.0
     # via twine
-secretstorage==3.3.3
-    # via keyring
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -14,8 +14,6 @@ astroid==3.0.1
     #   pylint-celery
 certifi==2023.11.17
     # via requests
-cffi==1.16.0
-    # via cryptography
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
@@ -32,8 +30,6 @@ coverage[toml]==7.3.2
     #   -r requirements/test.txt
     #   coverage
     #   pytest-cov
-cryptography==41.0.7
-    # via secretstorage
 dill==0.3.7
     # via pylint
 django==3.2.23
@@ -78,10 +74,6 @@ isort==5.12.0
     #   pylint
 jaraco-classes==3.3.0
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via code-annotations
 keyring==24.3.0
@@ -96,7 +88,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.1.0
     # via jaraco-classes
-nh3==0.2.14
+nh3==0.2.15
     # via readme-renderer
 packaging==23.2
     # via
@@ -115,8 +107,6 @@ pluggy==1.3.0
     #   pytest
 pycodestyle==2.11.1
     # via -r requirements/quality.in
-pycparser==2.21
-    # via cffi
 pydocstyle==6.3.0
     # via -r requirements/quality.in
 pygments==2.17.2
@@ -171,8 +161,6 @@ rfc3986==2.0.0
     # via twine
 rich==13.7.0
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via edx-lint
 snowballstemmer==2.2.0


### PR DESCRIPTION
## Description
- Remove `tox-battery` package requirement as it is not needed with `tox>4` anymore.
- Update `tox` to v4.