### PR TITLE
fix: aded dependency review GHA.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - "**"
 
+permissions:
+  contents: read
+
 jobs:
   run_tests:
     name: Tests
@@ -24,7 +27,14 @@ jobs:
           ]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: checkout repository
+        uses: actions/checkout@v4
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v3
+        with:
+          fail-on-severity: moderate
+
       - name: setup python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Made this PR to add Dependency review step on the top of CI. GitHub Dependency Review is a feature that helps you manage and keep track of your project's dependencies. The Dependency Review GitHub Action is an automated workflow that leverages this feature. It scans your project for known vulnerabilities in its dependencies and provides insights into security risks, enabling you to take necessary actions to address potential issues.

It would stop the CI if anything detected during Dependency Review on the Dependencies changes made in the PR being created.

Issue: https://github.com/edx/edx-arch-experiments/issues/358
POC: https://github.com/zubairshakoorarbisoft/api-doc-tools/actions/runs/7554260936/job/20566746292