### PR TITLE
Add support for Django 5.2 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         python-version: ["3.11", "3.12"]
         toxenv:
           [
-            django42-drflatest,quality
+            django42-drflatest,django52-drflatest,quality
           ]
 
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ----------
 
+2.1.0 - 2025-04-18
+---------------------
+* Added Support for ``django 5.2``.
+
 2.0.0 --- 2024-09-09
 --------------------
 * Drop support for Python 3.8

--- a/edx_api_doc_tools/__init__.py
+++ b/edx_api_doc_tools/__init__.py
@@ -46,4 +46,4 @@ from .view_utils import (
 )
 
 
-__version__ = '2.0.0'
+__version__ = '2.1.0'

--- a/pylintrc
+++ b/pylintrc
@@ -380,6 +380,6 @@ ext-import-graph =
 int-import-graph = 
 
 [EXCEPTIONS]
-overgeneral-exceptions = Exception
+overgeneral-exceptions = builtins.Exception
 
 # 264bfbfd3e646c58ffea0db9e4f1e268f0c8704d

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ def load_requirements(*requirements_paths):
         if seen_spelling is None:
             by_canonical_name[canonical] = package
         elif seen_spelling != package:
-            raise Exception(
+            raise RuntimeError(
                 f'Encountered both "{seen_spelling}" and "{package}" in requirements '
                 'and constraints files; please use just one or the other.'
             )
@@ -154,6 +154,7 @@ setup(
         'Development Status :: 3 - Alpha',
         'Framework :: Django',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,311,312}-django{42}-drf{latest} # Django 4.2 is not supported by DRF < 3.14
+    py{38,311,312}-django{42,52}-drf{latest} # Django 4.2 is not supported by DRF < 3.14
     quality
 
 [pytest]
@@ -11,6 +11,7 @@ norecursedirs = .* docs requirements
 [testenv]
 deps =
     django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
     drflatest: djangorestframework
     -r{toxinidir}/requirements/test.txt
 commands =


### PR DESCRIPTION
- Resolves [Issue](https://github.com/openedx/api-doc-tools/issues/329)

### Add Django 5.2 Support

This PR updates the codebase to be compatible with Django 5.2 while maintaining compatibility with Django 4.2.

Changes Made:
- Update `ci` and `tox` files
- Ran `django-upgrade` to apply necessary syntax updates for Django 5.2.
- Run tests using `tox` command and resolved the warning 
- Ensured all modifications remain backward-compatible with Django 4.2.

#### django-upgrade usage:

I ran command `git ls-files -z -- '*.py' | xargs -0r django-upgrade --target-version 5.2`