### PR TITLE
build: Fix builds by updating action to use Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.11", "3.12"]
-        toxenv:
-          [
-            django42-drflatest,django52-drflatest,quality
-          ]
+        toxenv: [django52-drflatest, quality]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -3,10 +3,9 @@ name: Publish package to PyPi
 on:
   push:
     tags:
-      - '*'
+      - "*"
 
 jobs:
-
   push:
     runs-on: ubuntu-latest
 
@@ -16,7 +15,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install pip
         run: pip install -r requirements/pip.txt
@@ -32,4 +31,3 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_UPLOAD_TOKEN }}
-

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ----------
 
+2.1.2 - 2026-01-39
+------------------
+* Fix builds to PyPI
+
 2.1.1 - 2026-01-39
 ------------------
 * Fix make upgrade, update dependencies

--- a/edx_api_doc_tools/__init__.py
+++ b/edx_api_doc_tools/__init__.py
@@ -46,4 +46,4 @@ from .view_utils import (
 )
 
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"

--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,11 @@ def get_version(*file_paths):
     Extract the version string from the file at the given relative path fragments.
     """
     filename = os.path.join(os.path.dirname(__file__), *file_paths)
-    version_file = open(filename,  encoding='utf-8').read()
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                              version_file, re.M)
+    version_file = open(filename, encoding="utf-8").read()
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
     if version_match:
         return version_match.group(1)
-    raise RuntimeError('Unable to find version string.')
+    raise RuntimeError("Unable to find version string.")
 
 
 def load_requirements(*requirements_paths):
@@ -49,14 +48,14 @@ def load_requirements(*requirements_paths):
         with extras we don't constrain it without mentioning the extras (since
         that too would interfere with matching constraints.)
         """
-        canonical = package.lower().replace('_', '-').split('[')[0]
+        canonical = package.lower().replace("_", "-").split("[")[0]
         seen_spelling = by_canonical_name.get(canonical)
         if seen_spelling is None:
             by_canonical_name[canonical] = package
         elif seen_spelling != package:
             raise RuntimeError(
                 f'Encountered both "{seen_spelling}" and "{package}" in requirements '
-                'and constraints files; please use just one or the other.'
+                "and constraints files; please use just one or the other."
             )
 
     requirements = {}
@@ -70,7 +69,9 @@ def load_requirements(*requirements_paths):
         % (re_package_name_base_chars, re_package_name_base_chars)
     )
 
-    def add_version_constraint_or_raise(current_line, current_requirements, add_if_not_present):
+    def add_version_constraint_or_raise(
+        current_line, current_requirements, add_if_not_present
+    ):
         regex_match = requirement_line_regex.match(current_line)
         if regex_match:
             package = regex_match.group(1)
@@ -79,11 +80,16 @@ def load_requirements(*requirements_paths):
             existing_version_constraints = current_requirements.get(package, None)
             # It's fine to add constraints to an unconstrained package,
             # but raise an error if there are already constraints in place.
-            if existing_version_constraints and existing_version_constraints != version_constraints:
-                raise BaseException(f'Multiple constraint definitions found for {package}:'
-                                    f' "{existing_version_constraints}" and "{version_constraints}".'
-                                    f'Combine constraints into one location with {package}'
-                                    f'{existing_version_constraints},{version_constraints}.')
+            if (
+                existing_version_constraints
+                and existing_version_constraints != version_constraints
+            ):
+                raise BaseException(
+                    f"Multiple constraint definitions found for {package}:"
+                    f' "{existing_version_constraints}" and "{version_constraints}".'
+                    f"Combine constraints into one location with {package}"
+                    f"{existing_version_constraints},{version_constraints}."
+                )
             if add_if_not_present or package in current_requirements:
                 current_requirements[package] = version_constraints
 
@@ -94,8 +100,12 @@ def load_requirements(*requirements_paths):
             for line in reqs:
                 if is_requirement(line):
                     add_version_constraint_or_raise(line, requirements, True)
-                if line and line.startswith('-c') and not line.startswith('-c http'):
-                    constraint_files.add(os.path.dirname(path) + '/' + line.split('#')[0].replace('-c', '').strip())
+                if line and line.startswith("-c") and not line.startswith("-c http"):
+                    constraint_files.add(
+                        os.path.dirname(path)
+                        + "/"
+                        + line.split("#")[0].replace("-c", "").strip()
+                    )
 
     # process constraint files: add constraints to existing requirements
     for constraint_file in constraint_files:
@@ -105,7 +115,9 @@ def load_requirements(*requirements_paths):
                     add_version_constraint_or_raise(line, requirements, False)
 
     # process back into list of pkg><=constraints strings
-    constrained_requirements = [f'{pkg}{version or ""}' for (pkg, version) in sorted(requirements.items())]
+    constrained_requirements = [
+        f"{pkg}{version or ''}" for (pkg, version) in sorted(requirements.items())
+    ]
     return constrained_requirements
 
 
@@ -119,48 +131,53 @@ def is_requirement(line):
     """
     # UPDATED VIA SEMGREP - if you need to remove/modify this method remove this line and add a comment specifying why
 
-    return line and line.strip() and not line.startswith(('-r', '#', '-e', 'git+', '-c'))
+    return (
+        line and line.strip() and not line.startswith(("-r", "#", "-e", "git+", "-c"))
+    )
 
 
-VERSION = get_version('edx_api_doc_tools', '__init__.py')
+VERSION = get_version("edx_api_doc_tools", "__init__.py")
 
-if sys.argv[-1] == 'tag':
+if sys.argv[-1] == "tag":
     print("Tagging the version on github:")
     os.system("git tag -a %s -m 'version %s'" % (VERSION, VERSION))
     os.system("git push --tags")
     sys.exit()
 
-README = open(os.path.join(os.path.dirname(__file__), 'README.rst'),  encoding='utf-8').read()
-CHANGELOG = open(os.path.join(os.path.dirname(__file__), 'CHANGELOG.rst'),  encoding='utf-8').read()
+README = open(
+    os.path.join(os.path.dirname(__file__), "README.rst"), encoding="utf-8"
+).read()
+CHANGELOG = open(
+    os.path.join(os.path.dirname(__file__), "CHANGELOG.rst"), encoding="utf-8"
+).read()
 
 setup(
-    name='edx-api-doc-tools',
+    name="edx-api-doc-tools",
     version=VERSION,
     description="Tools for writing and generating API documentation for edX REST APIs",
-    long_description=README + '\n\n' + CHANGELOG,
+    long_description=README + "\n\n" + CHANGELOG,
     long_description_content_type="text/x-rst",
-    author='Open edX Project',
-    author_email='oscm@openedx.org',
-    url='https://github.com/openedx/api-doc-tools',
+    author="Open edX Project",
+    author_email="oscm@openedx.org",
+    url="https://github.com/openedx/api-doc-tools",
     packages=[
-        'edx_api_doc_tools',
+        "edx_api_doc_tools",
     ],
     include_package_data=True,
-    install_requires=load_requirements('requirements/base.in'),
+    install_requires=load_requirements("requirements/base.in"),
     license="Apache Software License 2.0",
     zip_safe=False,
-    keywords='Django edx',
+    keywords="Django edx",
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Framework :: Django',
-        'Framework :: Django :: 4.2',
-        'Framework :: Django :: 5.2',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12',
+        "Development Status :: 3 - Alpha",
+        "Framework :: Django",
+        "Framework :: Django :: 4.2",
+        "Framework :: Django :: 5.2",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,311,312}-django{42,52}-drf{latest} # Django 4.2 is not supported by DRF < 3.14
+    py{311,312}-django{52}-drf{latest}
     quality
 
 [pytest]
@@ -10,7 +10,6 @@ norecursedirs = .* docs requirements
 
 [testenv]
 deps =
-    django42: Django>=4.2,<4.3
     django52: Django>=5.2,<5.3
     drflatest: djangorestframework
     -r{toxinidir}/requirements/test.txt
@@ -40,4 +39,3 @@ deps =
     -r{toxinidir}/requirements/quality.txt
 commands =
     make quality
-


### PR DESCRIPTION
Also:

- Removes the incorrect Python 3.8 classifier and fixes quotes in setup.py.
- Removes Django 4.2 and Python 3.8 from the test matrix